### PR TITLE
Fortalece a Política de Segurança de JWT

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -6,6 +6,8 @@ DB_PASSWORD=change-me
 # JWT Configuration
 JWT_SECRET=troque-por-um-segredo-seguro
 JWT_EXPIRES_IN=7d
+JWT_REFRESH_SECRET=troque-por-um-segredo-diferente-e-tambem-forte
+JWT_REFRESH_EXPIRES_IN=30d
 
 # Password hashing
 BCRYPT_SALT_ROUNDS=12

--- a/SOLUCOES.md
+++ b/SOLUCOES.md
@@ -122,3 +122,13 @@ Esta seção detalha as correções referentes à otimização do ambiente Docke
 * Ampliei a suíte com cenários negativos integrados, garantindo respostas 400 tanto para senha atual inválida quanto para confirmação divergente ao chamar `/auth/change-password`.
 * Estruturei recuperação de senha segura com tokens temporários (rotas `/auth/forgot-password` e `/auth/reset-password`), armazenando hash + expiração configurável e cobrindo fluxos felizes/negativos via Supertest.
 
+---
+
+## 4. Fortalecer segurança do JWT
+
+* Centralizei a configuração de tokens exigindo segredos fortes distintos para acesso e refresh, removendo fallbacks inseguros..
+* Bloqueei o uso de segredos idênticos entre acesso e refresh, forçando diferenciação já no boot da aplicação para mitigar reutilização indevida.
+* Criei o arquivo `env.ts` para facilitar a exeução dos testes.
+
+---
+

--- a/backend/jest.config.js
+++ b/backend/jest.config.js
@@ -14,5 +14,6 @@ module.exports = {
     '!src/**/*.d.ts',
     '!src/tests/**',
   ],
+  setupFiles: ['<rootDir>/src/tests/env.ts'],
   setupFilesAfterEnv: ['<rootDir>/src/tests/setup.ts'],
 };

--- a/backend/src/config/security.ts
+++ b/backend/src/config/security.ts
@@ -1,5 +1,8 @@
 const DEFAULT_SALT_ROUNDS = 12;
 const DEFAULT_RESET_TOKEN_EXPIRATION_MINUTES = 30;
+const MIN_JWT_SECRET_LENGTH = 32;
+const DEFAULT_JWT_EXPIRES_IN = '7d';
+const DEFAULT_REFRESH_EXPIRES_IN = '30d';
 
 const parseSaltRounds = (value: string | undefined): number => {
   if (!value) {
@@ -30,4 +33,40 @@ const parseResetExpiration = (value: string | undefined): number => {
 export const BCRYPT_SALT_ROUNDS = parseSaltRounds(process.env.BCRYPT_SALT_ROUNDS);
 export const PASSWORD_RESET_TOKEN_EXPIRATION_MINUTES = parseResetExpiration(
   process.env.PASSWORD_RESET_TOKEN_EXPIRATION_MINUTES
+);
+
+const ensureSecret = (value: string | undefined, envName: string): string => {
+  if (!value) {
+    throw new Error(`Variável ${envName} não configurada. Defina um segredo forte para proteger os tokens.`);
+  }
+
+  const secret = value.trim();
+  if (secret.length < MIN_JWT_SECRET_LENGTH) {
+    throw new Error(`Valor em ${envName} deve possuir ao menos ${MIN_JWT_SECRET_LENGTH} caracteres.`);
+  }
+
+  return secret;
+};
+
+const sanitizeExpiration = (value: string | undefined, fallback: string): string => {
+  if (!value || !value.trim()) {
+    return fallback;
+  }
+
+  return value.trim();
+};
+
+const resolvedAccessSecret = ensureSecret(process.env.JWT_SECRET, 'JWT_SECRET');
+const resolvedRefreshSecret = ensureSecret(process.env.JWT_REFRESH_SECRET, 'JWT_REFRESH_SECRET');
+
+if (resolvedAccessSecret === resolvedRefreshSecret) {
+  throw new Error('As variáveis JWT_SECRET e JWT_REFRESH_SECRET devem ser diferentes para reduzir riscos de vazamento.');
+}
+
+export const JWT_SECRET = resolvedAccessSecret;
+export const JWT_REFRESH_SECRET = resolvedRefreshSecret;
+export const JWT_EXPIRES_IN = sanitizeExpiration(process.env.JWT_EXPIRES_IN, DEFAULT_JWT_EXPIRES_IN);
+export const JWT_REFRESH_EXPIRES_IN = sanitizeExpiration(
+  process.env.JWT_REFRESH_EXPIRES_IN,
+  DEFAULT_REFRESH_EXPIRES_IN
 );

--- a/backend/src/middleware/auth.ts
+++ b/backend/src/middleware/auth.ts
@@ -1,7 +1,7 @@
 import { Request, Response, NextFunction } from 'express';
-import jwt from 'jsonwebtoken';
-import { AuthenticatedRequest, JWTPayload } from '../types';
+import { AuthenticatedRequest } from '../types';
 import { User } from '../models';
+import { verifyToken } from '../utils/jwt';
 
 export const authenticateToken = async (
   req: AuthenticatedRequest,
@@ -17,7 +17,7 @@ export const authenticateToken = async (
   }
 
   try {
-    const decoded = jwt.verify(token, process.env.JWT_SECRET || 'fallback-secret') as JWTPayload;
+  const decoded = verifyToken(token);
     
     // Verify user still exists
     const user = await User.findByPk(decoded.id);
@@ -53,7 +53,7 @@ export const optionalAuth = async (
   }
 
   try {
-    const decoded = jwt.verify(token, process.env.JWT_SECRET || 'fallback-secret') as JWTPayload;
+  const decoded = verifyToken(token);
     
     const user = await User.findByPk(decoded.id);
     if (user && user.isActive) {

--- a/backend/src/tests/env.ts
+++ b/backend/src/tests/env.ts
@@ -1,0 +1,5 @@
+// Mantemos segredos determinísticos nos testes para facilitar asserts.
+process.env.JWT_SECRET = process.env.JWT_SECRET ?? 'segredo-testes-acesso-1234567890';
+process.env.JWT_REFRESH_SECRET = process.env.JWT_REFRESH_SECRET ?? 'segredo-testes-refresh-0987654321';
+process.env.JWT_EXPIRES_IN = process.env.JWT_EXPIRES_IN ?? '1h';
+process.env.JWT_REFRESH_EXPIRES_IN = process.env.JWT_REFRESH_EXPIRES_IN ?? '30d';

--- a/backend/src/utils/jwt.ts
+++ b/backend/src/utils/jwt.ts
@@ -1,21 +1,36 @@
-import jwt from 'jsonwebtoken';
+import jwt, { SignOptions, VerifyOptions } from 'jsonwebtoken';
 import { JWTPayload } from '../types';
+import {
+  JWT_SECRET,
+  JWT_EXPIRES_IN,
+  JWT_REFRESH_SECRET,
+  JWT_REFRESH_EXPIRES_IN,
+} from '../config/security';
 
-const JWT_SECRET = process.env.JWT_SECRET || 'your-fallback-secret-key';
-const JWT_EXPIRES_IN = process.env.JWT_EXPIRES_IN || '7d';
-
-export const generateToken = (payload: Omit<JWTPayload, 'iat' | 'exp'>): string => {
-  return jwt.sign(payload as any, JWT_SECRET as any, {
-    expiresIn: JWT_EXPIRES_IN,
-  } as any);
+const accessTokenSignOptions: SignOptions = {
+  expiresIn: JWT_EXPIRES_IN as SignOptions['expiresIn'],
+  algorithm: 'HS512', // Mantemos uma cifra mais forte para evitar brute force.
 };
 
 export const verifyToken = (token: string): JWTPayload => {
-  return jwt.verify(token, JWT_SECRET as any) as JWTPayload;
+  const verifyOptions: VerifyOptions = { algorithms: ['HS512'] };
+  return jwt.verify(token, JWT_SECRET, verifyOptions) as JWTPayload;
+};
+
+const refreshTokenSignOptions: SignOptions = {
+  expiresIn: JWT_REFRESH_EXPIRES_IN as SignOptions['expiresIn'],
+  algorithm: 'HS512',
+};
+
+export const generateToken = (payload: Omit<JWTPayload, 'iat' | 'exp'>): string => {
+  return jwt.sign(payload, JWT_SECRET, accessTokenSignOptions);
 };
 
 export const generateRefreshToken = (payload: Omit<JWTPayload, 'iat' | 'exp'>): string => {
-  return jwt.sign(payload as any, JWT_SECRET as any, {
-    expiresIn: '30d',
-  } as any);
+  return jwt.sign(payload, JWT_REFRESH_SECRET, refreshTokenSignOptions);
+};
+
+export const verifyRefreshToken = (token: string): JWTPayload => {
+  const verifyOptions: VerifyOptions = { algorithms: ['HS512'] };
+  return jwt.verify(token, JWT_REFRESH_SECRET, verifyOptions) as JWTPayload;
 };


### PR DESCRIPTION
Este PR implementa a tarefa crítica de segurança "Fortalecer segurança do JWT", a implementação anterior continha fallbacks inseguros.

### O que foi feito?
* Toda a lógica de configuração de JWTs (segredos, expirações, algoritmo) foi centralizada no novo arquivo security.ts.

* A aplicação agora valida as variáveis de ambiente na inicialização, ela se recusa a iniciar se os segredos de JWT forem muito curtos ou se os segredos de access e refresh forem idênticos.

* Foi introduzida a variável JWT_REFRESH_SECRET para separar o ciclo de vida dos access tokens e refresh tokens.

* O algoritmo de assinatura dos tokens foi atualizado para HS512.

* Todo e qualquer fallback para segredos de JWT que existia no código foi removido. A aplicação agora depende exclusivamente das variáveis de ambiente.

* Para garantir que os testes sejam consistentes e não dependam de arquivos .env locais, o Jest foi configurado (jest.config.js) para usar um arquivo de setup (src/tests/env.ts) que injeta as variáveis de ambiente necessárias antes da execução dos testes.