### PR TITLE
Corrige e Refatora as Suítes de Teste do Backend e Frontend

### DIFF
--- a/SOLUCOES.md
+++ b/SOLUCOES.md
@@ -122,13 +122,15 @@ Esta seção detalha as correções referentes à otimização do ambiente Docke
 * Ampliei a suíte com cenários negativos integrados, garantindo respostas 400 tanto para senha atual inválida quanto para confirmação divergente ao chamar `/auth/change-password`.
 * Estruturei recuperação de senha segura com tokens temporários (rotas `/auth/forgot-password` e `/auth/reset-password`), armazenando hash + expiração configurável e cobrindo fluxos felizes/negativos via Supertest.
 
----
-
 ## 4. Fortalecer segurança do JWT
 
 * Centralizei a configuração de tokens exigindo segredos fortes distintos para acesso e refresh, removendo fallbacks inseguros..
 * Bloqueei o uso de segredos idênticos entre acesso e refresh, forçando diferenciação já no boot da aplicação para mitigar reutilização indevida.
-* Criei o arquivo `env.ts` para facilitar a exeução dos testes.
+* Criei o arquivo `env.ts` para facilitar a exeução
 
 ---
+
+## 5. Correções de Testes Backend
+
+* Reescrevi asserções artificiais do `auth.test.ts` para validar serialização segura de usuários e garantir a verificação de tokens com `verifyToken`.
 

--- a/SOLUCOES.md
+++ b/SOLUCOES.md
@@ -134,3 +134,8 @@ Esta seção detalha as correções referentes à otimização do ambiente Docke
 
 * Reescrevi asserções artificiais do `auth.test.ts` para validar serialização segura de usuários e garantir a verificação de tokens com `verifyToken`.
 
+---
+
+## 6. Correções de Testes Frontend
+
+* Ajustei `test-utils.tsx` para permitir rotas controladas, filtrei a prop `hasError` nos inputs estilizados e reescrevi `App.test.tsx` validando a tela de login real e o link de cadastro.

--- a/frontend/src/App.test.tsx
+++ b/frontend/src/App.test.tsx
@@ -2,17 +2,20 @@ import React from 'react';
 import { render, screen } from './test-utils';
 import App from './App';
 
-// Intentionally broken test for evaluation
-test('renders learn react link', () => {
-  render(<App />);
-  const linkElement = screen.getByText(/learn react/i);
-  expect(linkElement).toBeInTheDocument();
+test('exibe a tela de login para visitantes', async () => {
+  render(<App />, { route: '/login' });
+
+  const title = await screen.findByRole('heading', { name: /welcome back/i });
+  expect(title).toBeInTheDocument();
+
+  const submitButton = screen.getByRole('button', { name: /sign in/i });
+  expect(submitButton).toBeInTheDocument();
 });
 
-// Another intentionally broken test
-test('should fail - broken test for evaluation', () => {
-  render(<App />);
-  // This will fail because we don't have this text in our app
-  const nonExistentElement = screen.getByText(/this text does not exist/i);
-  expect(nonExistentElement).toBeInTheDocument();
+test('mostra link para cadastro a partir do login', async () => {
+  render(<App />, { route: '/login' });
+
+  await screen.findByRole('heading', { name: /welcome back/i });
+  const registerLink = screen.getByRole('link', { name: /sign up here/i });
+  expect(registerLink).toHaveAttribute('href', '/register');
 });

--- a/frontend/src/components/forms/index.ts
+++ b/frontend/src/components/forms/index.ts
@@ -19,7 +19,9 @@ export const Label = styled.label`
   cursor: pointer;
 `;
 
-export const Input = styled.input<{ hasError?: boolean }>`
+export const Input = styled.input.withConfig({
+  shouldForwardProp: (prop) => prop !== 'hasError',
+})<{ hasError?: boolean }>`
   padding: ${({ theme }) => theme.space[3]};
   border: 1px solid ${({ theme, hasError }) => 
     hasError ? theme.colors.red[500] : theme.colors.gray[300]};
@@ -40,7 +42,9 @@ export const Input = styled.input<{ hasError?: boolean }>`
   }
 `;
 
-export const TextArea = styled.textarea<{ hasError?: boolean }>`
+export const TextArea = styled.textarea.withConfig({
+  shouldForwardProp: (prop) => prop !== 'hasError',
+})<{ hasError?: boolean }>`
   padding: ${({ theme }) => theme.space[3]};
   border: 1px solid ${({ theme, hasError }) => 
     hasError ? theme.colors.red[500] : theme.colors.gray[300]};
@@ -64,7 +68,9 @@ export const TextArea = styled.textarea<{ hasError?: boolean }>`
   }
 `;
 
-export const Select = styled.select<{ hasError?: boolean }>`
+export const Select = styled.select.withConfig({
+  shouldForwardProp: (prop) => prop !== 'hasError',
+})<{ hasError?: boolean }>`
   padding: ${({ theme }) => theme.space[3]};
   border: 1px solid ${({ theme, hasError }) => 
     hasError ? theme.colors.red[500] : theme.colors.gray[300]};

--- a/frontend/src/test-utils.tsx
+++ b/frontend/src/test-utils.tsx
@@ -2,26 +2,38 @@ import React, { ReactElement } from 'react';
 import { render, RenderOptions } from '@testing-library/react';
 import { ThemeProvider } from 'styled-components';
 import { MemoryRouter } from 'react-router-dom';
-import { AuthProvider } from './hooks/useAuth';   
+import { AuthProvider } from './hooks/useAuth';
 import { theme } from './styles/theme';
 
-const AllTheProviders = ({ children }: { children: React.ReactNode }) => {
+interface AllProvidersProps {
+  children: React.ReactNode;
+  initialEntries?: string[];
+}
+
+const AllTheProviders = ({ children, initialEntries }: AllProvidersProps) => {
   return (
-    
     <ThemeProvider theme={theme}>
-      <MemoryRouter>
-        <AuthProvider>
-          {children}
-        </AuthProvider>
+      <MemoryRouter initialEntries={initialEntries}>
+        <AuthProvider>{children}</AuthProvider>
       </MemoryRouter>
     </ThemeProvider>
   );
 };
 
+interface CustomRenderOptions extends Omit<RenderOptions, 'wrapper'> {
+  route?: string;
+}
+
 const customRender = (
   ui: ReactElement,
-  options?: Omit<RenderOptions, 'wrapper'>,
-) => render(ui, { wrapper: AllTheProviders, ...options });
+  { route = '/', ...options }: CustomRenderOptions = {},
+) => {
+  const Wrapper = ({ children }: { children: React.ReactNode }) => (
+    <AllTheProviders initialEntries={[route]}>{children}</AllTheProviders>
+  );
+
+  return render(ui, { wrapper: Wrapper, ...options });
+};
 
 export * from '@testing-library/react';
 


### PR DESCRIPTION
Este PR resolve a tarefa crítica "Corrigir asserções nos testes de Backend e Frontend". O projeto continha testes intencionalmente quebrados e configurações de teste inadequadas, o que tornava a suíte de testes inútil como ferramenta de garantia de qualidade.

### O que foi feito?
* Os testes artificiais e quebrados foram removidos e substituídos por cenários de teste realistas e úteis.

* Foram adicionados novos testes para validar a serialização segura do modelo User e a lógica de validação de tokens, cobrindo a verificação de tokens válidos e a rejeição de tokens inválidos.

* O utilitário de testes (test-utils.tsx) foi aprimorado para suportar a passagem de rotas iniciais, facilitando o teste de componentes que dependem de roteamento.

* Os testes do componente principal foram completamente reescritos para validar a renderização da tela de login real, em vez de procurar por textos de placeholder que não existem na aplicação.

* Foi corrigido um warning do React nos componentes de formulário, impedindo que a prop customizada hasError fosse repassada diretamente ao DOM.