### PR TITLE
Resolve N+1 Queries e Refatora Modelo de Post

### DIFF
--- a/SOLUCOES.md
+++ b/SOLUCOES.md
@@ -146,3 +146,4 @@ Esta seção detalha as correções referentes à otimização do ambiente Docke
 
 * Reescrevi o `getPosts` para carregar autores, comentários e contagens em uma única consulta via `findAll` com `include` e agregações `COUNT`, eliminando os laços que disparavam queries adicionais por post.
 * Ajustei `getPostById` para carregar comentários e seus autores em eager loading, mantendo as contagens de likes em SQL e serializando a resposta em um único payload.
+* Removi o helper `Post.getCommentsWithAuthors`, que permanecia como exemplo quebrado.

--- a/SOLUCOES.md
+++ b/SOLUCOES.md
@@ -6,7 +6,7 @@ Este levantamento servirá como um roteiro para as correções e implementaçõe
 
 ## 1. Diagnóstico por Componente
 
-### 1.1. Infraestrutura e Ambiente (DevOps)
+### 1.1. Infraestrutura e Ambiente
 
 #### 1.1.1. Execução via Docker
 * A execução do comando `docker compose up -d` apresenta problemas. Em ambiente atual, há alto risco de falha tanto no backend quanto no frontend durante o build/execução em containers.
@@ -139,3 +139,10 @@ Esta seção detalha as correções referentes à otimização do ambiente Docke
 ## 6. Correções de Testes Frontend
 
 * Ajustei `test-utils.tsx` para permitir rotas controladas, filtrei a prop `hasError` nos inputs estilizados e reescrevi `App.test.tsx` validando a tela de login real e o link de cadastro.
+
+---
+
+## 7. Performance no Feed de Posts
+
+* Reescrevi o `getPosts` para carregar autores, comentários e contagens em uma única consulta via `findAll` com `include` e agregações `COUNT`, eliminando os laços que disparavam queries adicionais por post.
+* Ajustei `getPostById` para carregar comentários e seus autores em eager loading, mantendo as contagens de likes em SQL e serializando a resposta em um único payload.

--- a/backend/.env.example
+++ b/backend/.env.example
@@ -12,6 +12,8 @@ DB_PASSWORD=password123
 # JWT Configuration
 JWT_SECRET=your-super-secret-jwt-key-here-change-in-production
 JWT_EXPIRES_IN=7d
+JWT_REFRESH_SECRET=troque-por-um-segredo-diferente-e-tambem-forte
+JWT_REFRESH_EXPIRES_IN=30d
 
 # Password hashing
 BCRYPT_SALT_ROUNDS=12

--- a/backend/src/models/Post.ts
+++ b/backend/src/models/Post.ts
@@ -53,22 +53,6 @@ class Post extends Model<PostAttributes, PostCreationAttributes> implements Post
     likes: Association<Post, any>;
   };
 
-  // Intentionally inefficient method that will cause N+1 queries
-  public async getCommentsWithAuthors(): Promise<any[]> {
-    const comments = await this.getComments();
-    const commentsWithAuthors = [];
-    
-    // N+1 Query Problem: This will make a separate query for each comment's author
-    for (const comment of comments) {
-      const author = await comment.getAuthor();
-      commentsWithAuthors.push({
-        ...comment.toJSON(),
-        author: author.toJSON()
-      });
-    }
-    
-    return commentsWithAuthors;
-  }
 }
 
 Post.init(


### PR DESCRIPTION
Este PR resolve o problema crítico de performance relacionado a N+1 queries. Os endpoints de listagem e detalhe de posts estavam executando um número excessivo de consultas ao banco de dados, o que comprometia a escalabilidade e o tempo de resposta da API.

### O que foi feito?
* Os métodos getPosts e getPostById no postController.ts foram refatorados para utilizar eager loading através do include do Sequelize.

* Essa mudança garante que os dados associados (autor, comentários, likes) sejam carregados em uma única consulta otimizada.

* O método legado e ineficiente Post.getCommentsWithAuthors, que era a fonte do padrão N+1, foi completamente removido do modelo Post.ts.